### PR TITLE
Added Filename to Collection Items

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,7 @@ function plugin(opts){
         metadata[key] = metadata[key] || [];
         metadata[key].push(data);
         data.collection = key;
+        data.file = file;
       });
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -129,6 +129,19 @@ describe('metalsmith-collections', function(){
       });
   });
 
+  it('should add the file name', function(done){
+    var metalsmith = Metalsmith('test/fixtures/basic');
+    metalsmith
+      .use(collections({ articles: {}}))
+      .build(function(err){
+        if (err) return done(err);
+        var articles = metalsmith.metadata().articles;
+        assert.equal(articles[0].file, 'one.md');
+        assert.equal(articles[1].file, 'two.md');
+        done();
+      });
+  });
+
   it('should not fail with empty collections', function(done) {
     var metalsmith = Metalsmith('test/fixtures/empty');
     metalsmith


### PR DESCRIPTION
`collections` contains lists of references to files found within
that collection, however you cannot figure out their originating file
structure from that file object alone.

By storing the filename within each collection item, we enable plugins
to understand the source (and destination) file structure.
