### PR TITLE
Added 'newer' and 'older' references

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # metalsmith-collections
 
-A [Metalsmith](https://github.com/segmentio/metalsmith) plugin that lets you group files together into an ordered collection, like blog posts. That way you can loop over them to generate an index, or add 'next' and 'previous' links between them.
+A [Metalsmith](https://github.com/segmentio/metalsmith) plugin that lets you group files together into an ordered collection, like blog posts. That way you can loop over them to generate an index, or add 'next', 'previous', 'newer' and 'older' links between them.
 
 ## Features
 
@@ -9,6 +9,7 @@ A [Metalsmith](https://github.com/segmentio/metalsmith) plugin that lets you gro
   - can limit the number of files in a collection
   - adds collections to global metadata
   - adds `next` and `previous` references to each file in the collection
+  - adds `newer` and `older` references to each file in the collection
 
 ## Installation
 
@@ -120,6 +121,17 @@ By adding `refer: false` to your options, it will skip adding the "next" and
 metalsmith.use(collections({
   articles: {
     refer: false
+  }
+}));
+```
+
+By adding `chronologicalRefer: false` to your options, it will skip adding the "newer" and
+"older" links to your articles.
+
+```js
+metalsmith.use(collections({
+  articles: {
+    chronologicalRefer: false
   }
 }));
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -106,6 +106,32 @@ function plugin(opts){
     });
 
     /**
+     * Add `newer` and `older` references and apply the `limit` option
+     */
+
+    keys.forEach(function(key){
+      debug('chronological order referencing collection: %s', key);
+      var settings = opts[key];
+      var col = metadata[key];
+      var last = col.length - 1;
+      if (opts[key].limit && opts[key].limit < col.length) {
+          col = metadata[key] = col.slice(0, opts[key].limit);
+          last = opts[key].limit - 1;
+      }
+      if (settings.chronologicalRefer === false) return;
+
+      col.forEach(function(file, i){
+        if (settings.reverse) {
+          if (0 != i) file.newer = col[i-1];
+          if (last != i) file.older = col[i+1];
+        } else {
+          if (0 != i) file.older = col[i-1];
+          if (last != i) file.newer = col[i+1];
+        }
+      });
+    });
+
+    /**
      * Add collection metadata
      */
 


### PR DESCRIPTION
I propose new references 'newer' and 'older'.
These references keep chronological order.  In other words, they are free from 'reverse' setting.

Consider the following example.  Some users need both of the latest and oldest ordered collections.  In such case, 'previous' and 'next' references are broken because the references are overwritten, but 'newer' and 'older' work correctly.

```
metalsmith.use(collections({
  latest: {
    pattern: '*.md',
    sortBy: 'date',
    reverse: true
  },
  oldest: {
    pattern: '*.md',
    sortBy: 'date',
    reverse: false
  }
}));
```