### PR TITLE
Fix: conditional exports types

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "type": "module",
   "types": "./lib/index.d.ts",
   "exports": {
+    "types": "./lib/index.d.ts",
     "import": "./lib/index.js",
     "require": "./lib/index.cjs"
   },


### PR DESCRIPTION
I do not know why, but Jest + TypeScript will not run without this change. The error it will give is:

```
  ● Test suite failed to run

    index.ts:1:47 - error TS7016: Could not find a declaration file for module '@metalsmith/collections'. '<redacted>/metalsmith-plugins/node_modules/@metalsmith/collections/lib/index.cjs' implicitly has an 'any' type.
      Try `npm i --save-dev @types/metalsmith__collections` if it exists or add a new declaration (.d.ts) file containing `declare module '@metalsmith/collections';`

    1 import collections, { CollectionConfig } from '@metalsmith/collections';
                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~
```

I'd love to embed this plugin inside a new one, but I'm entirely blocked on this change, unfortunately.